### PR TITLE
Add pytest coverage tracking with 75% threshold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=7.0",
+    "pytest-cov>=4.0",
     "ruff>=0.4",
 ]
 
@@ -39,3 +40,17 @@ select = ["E", "F", "I", "W"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = "--cov=src/jam_session_processor --cov-report=term-missing"
+
+[tool.coverage.run]
+source = ["src/jam_session_processor"]
+omit = ["tests/*"]
+
+[tool.coverage.report]
+fail_under = 75
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.",
+    "if TYPE_CHECKING:",
+]


### PR DESCRIPTION
## Summary
- Add `pytest-cov` to dev dependencies
- Configure coverage to run automatically with every `pytest` invocation via `addopts`
- Set `fail_under = 75%` threshold (current coverage is ~79%)
- Add `[tool.coverage.run]` and `[tool.coverage.report]` sections to `pyproject.toml`

Closes #12

## Test plan
- [x] Verified `pytest` runs coverage by default and prints term-missing report
- [x] Verified coverage threshold of 75% passes (current: 78.74%)
- [x] Verified lint passes on changed file (`pyproject.toml`)

https://claude.ai/code/session_01SD1XydmsC5wzkgg7YHHsuA