### PR TITLE
Fix failing tests and rename CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: PR Checks
 
 on:
   pull_request:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
 dev = [
     "pytest>=7.0",
     "ruff>=0.4",
+    "httpx>=0.27",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- Add `httpx` to dev dependencies — required by FastAPI's `TestClient` but missing, causing all API tests to fail in CI
- Rename workflow from "CI" to "PR Checks" for clarity

## Test plan
- [ ] Verify Python Tests job now passes in CI
- [ ] Confirm workflow shows as "PR Checks" in GitHub Actions

https://claude.ai/code/session_01Lv5DmLo1ncvjdQCVH94xrc